### PR TITLE
Switched the position of the key from app.json to secret.js 

### DIFF
--- a/FindMyClass/app.json
+++ b/FindMyClass/app.json
@@ -33,10 +33,6 @@
           "backgroundColor": "#ffffff"
         }
       ]
-    ],
-    "experiments": {
-      "typedRoutes": true
-    }
-    
+    ]
   }
 } 

--- a/FindMyClass/app/screens/directions.jsx
+++ b/FindMyClass/app/screens/directions.jsx
@@ -5,7 +5,7 @@ import { View, Text, Alert, Platform, StyleSheet, TextInput, TouchableOpacity } 
 import { Dropdown } from 'react-native-element-dropdown';
 import { useLocalSearchParams } from "expo-router";
 import polyline from "@mapbox/polyline";
-import { googleAPIKey } from "../app/secrets";
+import { googleAPIKey } from "../../app/secrets";
 import SGWBuildings from '../../components/SGWBuildings';
 import LoyolaBuildings from '../../components/loyolaBuildings';
 import GoogleSearchBar from "../../components/GoogleSearchBar";

--- a/FindMyClass/jest.setup.js
+++ b/FindMyClass/jest.setup.js
@@ -11,15 +11,6 @@ jest.mock('expo-splash-screen', () => ({
   preventAutoHideAsync: jest.fn(),
 }));
 
-// Mock `expo-constants` (✅ Fixes Jest error)
-jest.mock('expo-constants', () => ({
-  expoConfig: {
-    extra: {
-      OPENAI_API_KEY: 'mocked-api-key', // Mocked API Key for testing
-    },
-  },
-}));
-
 // Mock `expo-modules-core`
 jest.mock('expo-modules-core', () => ({
   NativeModulesProxy: { ExponentDevice: { getPlatformName: () => 'ios' } },

--- a/FindMyClass/services/openai.js
+++ b/FindMyClass/services/openai.js
@@ -1,11 +1,8 @@
 import axios from 'axios';
-import Constants from 'expo-constants';
-
-// Retrieve the OpenAI API key from Expo constants
-const OPENAI_API_KEY = Constants.expoConfig?.extra?.OPENAI_API_KEY;
+import { openaiAPIKey } from "../app/secrets";
 
 // Validate API key existence
-if (!OPENAI_API_KEY) {
+if (!openaiAPIKey) {
   throw new Error('OpenAI API key is missing. Ensure it is defined in your environment variables.');
 }
 
@@ -13,7 +10,7 @@ if (!OPENAI_API_KEY) {
 const api = axios.create({
   baseURL: 'https://api.openai.com/v1',
   headers: {
-    Authorization: `Bearer ${OPENAI_API_KEY}`, // Fixed string interpolation for Bearer token
+    Authorization: `Bearer ${openaiAPIKey}`, // Fixed string interpolation for Bearer token
     'Content-Type': 'application/json',
   },
 });


### PR DESCRIPTION
Closes #68
We decided to move the key from app.json to secret.js so that we no longer have to copy the app.json file every time. Since the key was there we included it in the git ignore. Now that the key is no longer there we can push the app.json file and not be lost in these additions.