### PR TITLE
Link for schedule page

### DIFF
--- a/FindMyClass/app/screens/profile.jsx
+++ b/FindMyClass/app/screens/profile.jsx
@@ -88,6 +88,10 @@ export default function Profile() {
           <Text style={styles.changeText}>Change Photo</Text>
         </TouchableOpacity>
         <Text style={styles.userText}>Welcome, {user.email}</Text>
+        {/* New button for viewing schedule */}
+        <TouchableOpacity style={styles.scheduleButton} onPress={() => router.push('/screens/schedule')}>
+          <Text style={styles.scheduleButtonText}>View My Schedule</Text>
+        </TouchableOpacity>
       </View>
       <FloatingChatButton />
     </View>
@@ -154,6 +158,18 @@ const styles = StyleSheet.create({
     fontSize: 22,
     fontWeight: '600',
     color: '#333',
+  },
+  scheduleButton: {
+    backgroundColor: '#800000',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+    marginTop: 15,
+  },
+  scheduleButtonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
   },
   warning: {
     fontSize: 18,

--- a/FindMyClass/components/ProfileButton.jsx
+++ b/FindMyClass/components/ProfileButton.jsx
@@ -20,7 +20,7 @@ const ProfileButton = () => {
       }
     } else {
       if (option === 'login') {
-        router.push('/screens/login');
+        router.push('/auth/login');
       } else if (option === 'signup') {
         router.push('/screens/register');
       }


### PR DESCRIPTION
### Summary  
This PR adds a link to the Schedule page from the Profile page, allowing users to navigate easily.

### Changes Made:  
- Added a **"View Schedule"** button/link on the Profile page.  
- Ensured navigation to `/screens/schedule` when clicked.  
- Styled the link/button to match the existing UI design.

<img width="1512" alt="Screenshot 2025-02-24 at 8 32 24 PM" src="https://github.com/user-attachments/assets/1bad4bff-3c8a-4ad1-b78f-cea7bad15b3c" />

Closes #79 