### PR TITLE
Routing between pages bug fixed

### DIFF
--- a/FindMyClass/components/ProfileButton.jsx
+++ b/FindMyClass/components/ProfileButton.jsx
@@ -22,7 +22,7 @@ const ProfileButton = () => {
       if (option === 'login') {
         router.push('/auth/login');
       } else if (option === 'signup') {
-        router.push('/screens/register');
+        router.push('/auth/register');
       }
     }
   };

--- a/FindMyClass/components/directions/LocationSelector.js
+++ b/FindMyClass/components/directions/LocationSelector.js
@@ -148,7 +148,7 @@ const LocationSelector = ({
        
             <TouchableOpacity 
                 style={styles.leftArrow} 
-                onPress={() => router.push("index")}
+                onPress={() => router.push("/")}
                 testID="back-button"
             >
                 <FontAwesome5 name="arrow-left" size={24} color="#E9D3D7" />

--- a/FindMyClass/package-lock.json
+++ b/FindMyClass/package-lock.json
@@ -7672,7 +7672,6 @@
       "version": "16.0.6",
       "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.0.6.tgz",
       "integrity": "sha512-HN4xZirFjsFDIsWFb12AZh19fRzuvZjj2ll17cGr19VNRP06S/VPQU3Tdccn5vwUzQhOBlLu704CnNm278boiQ==",
-      "license": "MIT",
       "dependencies": {
         "expo-image-loader": "~5.0.0"
       },


### PR DESCRIPTION
This PR Closes #112 

The bug was fixed by updating the path leading to the pages :
- The back button in the Directions screen now leads correctly to the Map page
- The sign-up button that appears from clicking on the profile button icon now leads correctly to the Register page