### PR TITLE
Feature/differentiation of paths in public transportation mode

### DIFF
--- a/FindMyClass/app/screens/directions.jsx
+++ b/FindMyClass/app/screens/directions.jsx
@@ -126,7 +126,7 @@ export default function DirectionsScreen() {
                             latitude: lat,
                             longitude: lng
                         }));
-                        setCoordinates([{ coordinates: decodedCoordinates, color: "gray", width: 4 }]);
+                        setCoordinates([{ coordinates: decodedCoordinates, color: "#912338", width: 4 }]);
                         setRouteInfo({ distance: "Shuttle departing at:", duration: `${nextTime}` });
                     }
                 } catch (err) {

--- a/FindMyClass/app/screens/directions.jsx
+++ b/FindMyClass/app/screens/directions.jsx
@@ -191,9 +191,9 @@ export default function DirectionsScreen() {
                         if (line.vehicle.type === "BUS") {
                             segmentColor = "purple"; // Bus color
                         } else if (line.vehicle.type === "SUBWAY") {
-                            if (line.name.includes("Green")) segmentColor = "green";
-                            else if (line.name.includes("Blue")) segmentColor = "darkblue";
-                            else if (line.name.includes("Yellow")) segmentColor = "yellow";
+                            if (line.name.includes("Verte")) segmentColor = "green";
+                            else if (line.name.includes("Bleue")) segmentColor = "darkblue";
+                            else if (line.name.includes("Jaune")) segmentColor = "yellow";
                             else if (line.name.includes("Orange")) segmentColor = "orange";
                         }
                         lineWidth = 6; // Thicker for transit
@@ -414,9 +414,7 @@ export default function DirectionsScreen() {
                                 lineDashPattern={segment.isDashed ? [5, 5] : undefined} // Dashed for walking only
                             />
                         ))}
-
-
-
+                        
                     </MapView>
                 </View>
 


### PR DESCRIPTION
Differentiation of paths in public transportation mode

Overview

This PR introduces visual enhancements to our outdoor directions navigation system, by changing the way the lines look to make it easier for users to understand the route they re taking

What’s New
• Lines visual change:
Each metro line has its own color: Green line is in green, Yellow line in yellow, Blue line in blue and Orange line in orange
The buses are represented by a purple line holding the bus number in the middle of a white box in the middle of the line
Cars are represented with a normal blue line
Walking is now a dashed blue line 

• Transition points:
Whenever a user has to go from walking to Bus, Walking to metro or metro to metro, it is marked on the map by a white circle clearly showing a change of line.
I was unable to do it for when a user goes from bus or metro to walking.

• Bug fixes
Multiple requests could be sent at the same time and when switching too fast from walking to by car for example, the application would glitch back to walking multiple times.
The line for the car would randomly appear to be discontinuous as if it was the walking line.


How to Test
1. Launch and run the app
2. When in the app you directly get to the directions page.
3. Click on a SGW building and try the three ways to get there from your house. 
4. Set Loyola as your location and try using the shuttle bus
5. try different lines to see the transition points.
6. Try to break the code by switching transportation modes quickly

Demo:

https://github.com/user-attachments/assets/debdd017-b1f8-4f96-ae32-7ad260aa135a

