### PR TITLE
Usability Testing using UXCam

### DIFF
--- a/FindMyClass/app/_layout.jsx
+++ b/FindMyClass/app/_layout.jsx
@@ -1,14 +1,68 @@
 import { Drawer } from 'expo-router/drawer';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import * as SplashScreen from 'expo-splash-screen';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, AppState } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { DrawerActions } from '@react-navigation/native';
 import { AuthProvider } from '../contexts/AuthContext';
 import ProfileButton from '../components/ProfileButton';
+import { usePathname } from 'expo-router';
+import RNUxcam from 'react-native-ux-cam';
+import { uxCamKey } from './secrets'; 
+import Constants from 'expo-constants';
 
 export default function Layout() {
+
+  const pathname = usePathname();
+
+  useEffect(() => {
+
+    if (Constants.appOwnership === 'expo') {
+      console.warn('Skipping UXCam, Running in Expo Go');
+      return;
+    }
+    // Initialize UXCam only once when the app starts
+    const configuration = {
+      userAppKey: uxCamKey,
+      enableAutomaticScreenNameTagging: false,
+      enableAdvancedGestureRecognition: true,
+      enableImprovedScreenCapture: true,
+    };
+
+    RNUxcam.startWithConfiguration(configuration);
+  }, []);
+
+  useEffect(() => {
+    // Tag the current screen name whenever route changes
+    RNUxcam.tagScreenName(pathname);
+  }, [pathname]);
+
+  // Detect UI Freeze
+  useEffect(() => {
+    let lastFrameTime = Date.now();
+
+    const detectFreeze = () => {
+      const now = Date.now();
+      const timeSinceLastFrame = now - lastFrameTime;
+
+      if (timeSinceLastFrame > 3000) { // If no frame update for 3+ seconds
+        RNUxcam.logEvent('AppFreezeDetected', {
+          screen: pathname,
+          freezeDuration: timeSinceLastFrame + 'ms',
+          timestamp: new Date().toISOString(),
+        });
+        console.warn(' App freeze detected:', timeSinceLastFrame, 'ms');
+      }
+
+      lastFrameTime = now;
+      requestAnimationFrame(detectFreeze);
+    };
+
+    requestAnimationFrame(detectFreeze);
+  }, []);
+
+
   // Removed searchText state since search bar is no longer needed for maps
   const fontsLoaded = true; // ✅ Remove useFonts if not using fonts
 

--- a/FindMyClass/app/_layout.jsx
+++ b/FindMyClass/app/_layout.jsx
@@ -2,7 +2,7 @@ import { Drawer } from 'expo-router/drawer';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useCallback, useEffect } from 'react';
 import * as SplashScreen from 'expo-splash-screen';
-import { View, Text, StyleSheet, TouchableOpacity, AppState } from 'react-native';
+import { Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { DrawerActions } from '@react-navigation/native';
 import { AuthProvider } from '../contexts/AuthContext';

--- a/FindMyClass/app/index.jsx
+++ b/FindMyClass/app/index.jsx
@@ -1,13 +1,32 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useRoute } from '@react-navigation/native'; 
 import ToggleCampusMap from '../components/ToggleCampusMap';
 import FloatingChatButton from '../components/FloatingChatButton';
 import 'react-native-get-random-values'
+import RNUxcam from 'react-native-ux-cam';
+import { uxCamKey } from './secrets';
 
-export default function MapScreen() {  // ✅ Renamed to avoid conflict
+export default function MapScreen() {  // Renamed to avoid conflict
   const route = useRoute();
   const searchText = route?.params?.searchText || ''; // Cleaner fallback
+  
+  useEffect(() => {
+  
+  RNUxcam.optIntoSchematicRecordings(); // Enable iOS screen recordings
+
+  const configuration = {
+      userAppKey: uxCamKey,  // Replace with your UXCam API key
+      enableAutomaticScreenNameTagging: false,
+      enableAdvancedGestureRecognition: true, // Default is true
+      enableImprovedScreenCapture: true, // Improves Android screen capture
+      occlusions: [], // Add occlusion settings if needed
+    };
+
+    RNUxcam.startWithConfiguration(configuration);
+  }, []);
+
+
 
   return (
     <View style={styles.container} testID="map-container">

--- a/FindMyClass/app/index.jsx
+++ b/FindMyClass/app/index.jsx
@@ -4,27 +4,12 @@ import { useRoute } from '@react-navigation/native';
 import ToggleCampusMap from '../components/ToggleCampusMap';
 import FloatingChatButton from '../components/FloatingChatButton';
 import 'react-native-get-random-values'
-import RNUxcam from 'react-native-ux-cam';
-import { uxCamKey } from './secrets';
+
 
 export default function MapScreen() {  // Renamed to avoid conflict
   const route = useRoute();
   const searchText = route?.params?.searchText || ''; // Cleaner fallback
   
-  useEffect(() => {
-  
-  RNUxcam.optIntoSchematicRecordings(); // Enable iOS screen recordings
-
-  const configuration = {
-      userAppKey: uxCamKey,  // Replace with your UXCam API key
-      enableAutomaticScreenNameTagging: false,
-      enableAdvancedGestureRecognition: true, // Default is true
-      enableImprovedScreenCapture: true, // Improves Android screen capture
-      occlusions: [], // Add occlusion settings if needed
-    };
-
-    RNUxcam.startWithConfiguration(configuration);
-  }, []);
 
 
 

--- a/FindMyClass/app/index.jsx
+++ b/FindMyClass/app/index.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useRoute } from '@react-navigation/native'; 
 import ToggleCampusMap from '../components/ToggleCampusMap';

--- a/FindMyClass/ios/FindMyClass/Info.plist
+++ b/FindMyClass/ios/FindMyClass/Info.plist
@@ -27,7 +27,6 @@
       <dict>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>myapp</string>
           <string>com.findmyclass.app</string>
         </array>
       </dict>
@@ -52,9 +51,9 @@
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your location</string>
     <key>NSLocationAlwaysUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <string>This app requires location access to track location in the background.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <string>This app requires location access to show nearby classes.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your microphone</string>
     <key>NSPhotoLibraryUsageDescription</key>

--- a/FindMyClass/ios/Podfile.lock
+++ b/FindMyClass/ios/Podfile.lock
@@ -1734,6 +1734,28 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNUxcam (6.0.5):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - UXCam (~> 3.6.22)
+    - Yoga
   - RNVectorIcons (10.2.0):
     - DoubleConversion
     - glog
@@ -1756,6 +1778,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.7.1)
+  - UXCam (3.6.22)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1853,12 +1876,14 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - RNUxcam (from `../node_modules/react-native-ux-cam`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
   trunk:
     - SocketRocket
+    - UXCam
 
 EXTERNAL SOURCES:
   boost:
@@ -2046,6 +2071,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNUxcam:
+    :path: "../node_modules/react-native-ux-cam"
   RNVectorIcons:
     :path: "../node_modules/react-native-vector-icons"
   Yoga:
@@ -2144,8 +2171,10 @@ SPEC CHECKSUMS:
   RNGestureHandler: 27a63f2218affdf1a426d56682f9b174904838b3
   RNReanimated: 66cf0f600a26d2b5e74c6e0b1c77c1ab1f62fc05
   RNScreens: 4a5ab20b324ed1e3fe3862796b8f8e0a6208c415
+  RNUxcam: c8b7e2d7c7c3515113a9f33a83e64ed68e44935c
   RNVectorIcons: 182892e7d1a2f27b52d3c627eca5d2665a22ee28
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
+  UXCam: 9ff7948ec24c7cad33c7f537dfd1b3b2c27335bf
   Yoga: be6f55a028e86c83ae066f018e9b5d24ffc45436
 
 PODFILE CHECKSUM: c34710c05a7194d677bbe56c599ab3e318fb9d31

--- a/FindMyClass/package-lock.json
+++ b/FindMyClass/package-lock.json
@@ -59,6 +59,7 @@
         "react-native-root-siblings": "^5.0.1",
         "react-native-safe-area-context": "^4.14.1",
         "react-native-screens": "~4.4.0",
+        "react-native-ux-cam": "^6.0.5",
         "react-native-vector-icons": "^10.2.0",
         "react-native-webview": "13.12.5",
         "use-latest-callback": "^0.2.3"
@@ -14871,6 +14872,14 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-ux-cam": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-ux-cam/-/react-native-ux-cam-6.0.5.tgz",
+      "integrity": "sha512-LXuqwZHlWe2Yxly7H+n4ynDw90RNN7MACQugc3Q+JpdBAL9CuxtkqJlcKUNnDSVzE2EACcxEru4RE5dyM/ZWWw==",
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-vector-icons": {

--- a/FindMyClass/package.json
+++ b/FindMyClass/package.json
@@ -65,6 +65,7 @@
     "react-native-root-siblings": "^5.0.1",
     "react-native-safe-area-context": "^4.14.1",
     "react-native-screens": "~4.4.0",
+    "react-native-ux-cam": "^6.0.5",
     "react-native-vector-icons": "^10.2.0",
     "react-native-webview": "13.12.5",
     "use-latest-callback": "^0.2.3"


### PR DESCRIPTION
This PR Closes #61 , #117 

**Description** 

This PR integrates UXCam to track usability metrics, identify rage taps, and detect potential UI freezes. It enables automatic session recording and event logging for improved user experience analysis.

**Changes: **
- Initialized UXCam globally in _layout.js, ensuring it starts once across the app.
- Added screen tracking using usePathname() to log navigation changes.
- Captured rage taps to correlate them with potential unresponsive UI states.
- Disabled UXCam in Expo Go to prevent compatibility issues while allowing local development.

**How to test**

Run in development mode
```bash 
npx expo run:ios
``` 
- Open the app and complete tasks
- Once the tasks needed are completed press `command + shift + H`
- Open UXCam dashboard to check the completed sessions.

