### PR TITLE
Location selector UI crash fixed

### DIFF
--- a/FindMyClass/app/screens/directions.jsx
+++ b/FindMyClass/app/screens/directions.jsx
@@ -65,6 +65,7 @@ export default function DirectionsScreen() {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [searchType, setSearchType] = useState("START");
   const [directions, setDirections] = useState([]);
+  const [layoutReady, setLayoutReady] = useState(false);
 
   if (errorMessage) {
     return <Text>{errorMessage}</Text>;
@@ -188,7 +189,10 @@ const handleError = (err) => {
   const updateRoute = (start, end) => {
     updateRouteWithMode(start, end, travelMode);
   };
-
+  useEffect(() => {
+    console.log('Modal visibility changed:', isModalVisible);
+  }, [isModalVisible]);
+  
   useEffect(() => {
     let locationSubscription;
 
@@ -252,8 +256,9 @@ const handleError = (err) => {
 
 
   return (
-    <View style={stylesB.mainContainer}>
-      <View style={stylesB.container}>
+    <View style={stylesB.mainContainer} onLayout={() => setLayoutReady(true)} >
+
+      <View style={stylesB.floatingContainer}> 
         {/* Place the LocationSelector ABOVE the MapView */}
         <LocationSelector
           startLocation={startLocation}
@@ -273,12 +278,15 @@ const handleError = (err) => {
           setDestinationName={setDestinationName}
           travelMode={travelMode}
           setTravelMode={setTravelMode}
-          setIsModalVisible={setIsModalVisible}
+          setIsModalVisible={(val) => layoutReady && setIsModalVisible(val)}
           setSearchType={setSearchType}
           updateRouteWithMode={updateRouteWithMode}
           updateRoute={updateRoute}
           // style={stylesB.locationSelector} // No absolute positioning
         />
+
+      </View>
+      <View style={stylesB.container}>
 
         {/* Now the map is below the selector */}
         <View style={stylesB.mapContainer}>
@@ -328,6 +336,10 @@ const handleError = (err) => {
         )}
       </View>
 
+      {routeInfo && directions.length > 0 && (
+        <SwipeUpModal distance={routeInfo.distance} duration={routeInfo.duration} directions={directions} />
+      )}
+      <View>
       <ModalSearchBars
         searchType={searchType}
         isModalVisible={isModalVisible}
@@ -346,9 +358,7 @@ const handleError = (err) => {
         setCustomDest={setCustomDest}
         setDestinationName={setDestinationName}
       />
-      {routeInfo && directions.length > 0 && (
-        <SwipeUpModal distance={routeInfo.distance} duration={routeInfo.duration} directions={directions} />
-      )}
+      </View>
     </View>
   );
 }
@@ -365,6 +375,13 @@ const stylesB = StyleSheet.create({
   mapContainer: {
     flex: 1,
     // marginTop: 10, // or some margin if you want to separate from the LocationSelector
+  },
+  floatingContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 10,
   },
   loadingCard: {
     position: "absolute",

--- a/FindMyClass/app/screens/directions.jsx
+++ b/FindMyClass/app/screens/directions.jsx
@@ -189,10 +189,7 @@ const handleError = (err) => {
   const updateRoute = (start, end) => {
     updateRouteWithMode(start, end, travelMode);
   };
-  useEffect(() => {
-    console.log('Modal visibility changed:', isModalVisible);
-  }, [isModalVisible]);
-  
+
   useEffect(() => {
     let locationSubscription;
 

--- a/FindMyClass/components/directions/LocationSelector.js
+++ b/FindMyClass/components/directions/LocationSelector.js
@@ -51,11 +51,14 @@ const LocationSelector = ({
         LoyolaCampus: { latitude: 45.458424, longitude: -73.640259 }
     };
 
+    const showModal = () => setTimeout(() => setIsModalVisible(true), 1);
+
+
     const handleStartLocationChange =  async (item) => {
             setSelectedStart(item.value);
             if (item.value === 'custom') {  
                 setSearchType("START");
-                setIsModalVisible(true);
+                showModal();
             } else {
                 let newStartLocation;
                 switch(item.value) {
@@ -100,7 +103,7 @@ const LocationSelector = ({
                 setSelectedDest(item.value);
                 if (item.value === 'custom') {
                     setSearchType("DESTINATION");
-                    setIsModalVisible(true);
+                    showModal();
                 } else {
                     if (item.value !== 'custom') {
                         let newDestination;


### PR DESCRIPTION
This PR Closes #168 

The bug was fixed by delaying the opening of the modal by 1 millisecond: 
- `setIsModalVisible` now is executed using the function `showModal` which delays the execution by 1 ms. 
- `<LocationSelector />` and `<ModalSearchBars />` have been moved out of the same `<View>` as the `<MapView />` which prevents and UI freeze from happening.
- Additionally, some styling adjustments have been added to `<LocationSelector />` so it can float correctly on top of the map


Demo: 
https://github.com/user-attachments/assets/6db7efaf-e26a-40e3-9131-a91bec797526



